### PR TITLE
Convert dask-awkward-feedstock to v1 feedstock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Rattler-build's artifacts are in `output` when not specifying anything.
 /output
+# Pixi's configuration
+.pixi

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,21 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
-mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
-echo > /opt/conda/conda-meta/history
-micromamba install --root-prefix ~/.conda --prefix /opt/conda \
-    --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+curl -fsSL https://pixi.sh/install.sh | bash
+export PATH="~/.pixi/bin:$PATH"
+pushd "${FEEDSTOCK_ROOT}"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
+fi
+sed -i.bak "s/platforms = .*/platforms = [\"linux-${arch}\"]/" pixi.toml
+echo "Creating environment"
+PIXI_CACHE_DIR=/opt/conda pixi install
+pixi list
+echo "Activating environment"
+eval "$(pixi shell-hook)"
+mv pixi.toml.bak pixi.toml
+popd
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc
@@ -57,20 +67,16 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-
-    # Drop into an interactive shell
-    /bin/bash
+    echo "rattler-build currently doesn't support debug mode"
 else
-    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
-        --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+
+    rattler-build build --recipe "${RECIPE_ROOT}" \
+     -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+     ${EXTRA_CB_OPTIONS:-} \
+     --target-platform "${HOST_PLATFORM}" \
+     --extra-meta flow_run_id="${flow_run_id:-}" \
+     --extra-meta remote_url="${remote_url:-}" \
+     --extra-meta sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Documentation: https://dask-awkward.readthedocs.io/
 dask-awkward provides a native Dask collection representing
 partitioned awkward arrays.
 
-
 Current build status
 ====================
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,3 +4,5 @@ github:
 conda_forge_output_validation: true
 conda_build:
   pkg_format: '2'
+conda_install_tool: pixi
+conda_build_tool: rattler-build

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,34 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: toml -*-
+
+[project]
+name = "dask-awkward-feedstock"
+version = "3.47.0"
+description = "Pixi configuration for conda-forge/dask-awkward-feedstock"
+authors = ["@conda-forge/dask-awkward"]
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-64", "win-64"]
+
+[dependencies]
+conda-build = ">=24.1"
+conda-forge-ci-setup = "4.*"
+rattler-build = "*"
+
+[tasks]
+inspect-all = "inspect_artifacts --all-packages"
+build = "rattler-build build --recipe recipe"
+"build-linux_64_" = "rattler-build build --recipe recipe -m .ci_support/linux_64_.yaml"
+"inspect-linux_64_" = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_.yaml"
+
+[feature.smithy.dependencies]
+conda-smithy = "*"
+
+[feature.smithy.tasks]
+build-locally = "python ./build-locally.py"
+smithy = "conda-smithy"
+rerender = "conda-smithy rerender"
+lint = "conda-smithy lint recipe"
+
+[environments]
+smithy = ["smithy"]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,49 +1,54 @@
-{% set name = "dask-awkward" %}
-{% set version = "2025.2.0" %}
-{% set python_min = "3.8" %}
+schema_version: 1
+
+context:
+  name: dask-awkward
+  version: 2025.2.0
+  python_min: 3.8
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: ${{ name|lower }}
+  version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/d/dask_awkward/dask_awkward-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/d/dask_awkward/dask_awkward-${{ version }}.tar.gz
   sha256: 665df70be4f0394e8fa4ef50fcd80272f72cef6a4784e7f935e091d093d9aa2a
 
 build:
+  number: 1
   noarch: python
-  number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: ${{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python 3.8.*
     - pip
     - hatchling >=1.8.0
     - hatch-vcs
     - toml
   run:
-    - python >={{ python_min }}
+    - python >=${{ python_min }}
     - awkward >=2.5.1
     - dask >=2023.04.0
     - cachetools
     - typing_extensions >=4.8.0
 
-test:
-  imports:
-    - dask_awkward
+tests:
+  - python:
+      imports:
+        - dask_awkward
+      pip_check: false
 
+      python_version: ${{ python_min }}.*
 about:
-  home: https://dask-awkward.readthedocs.io/
   license: BSD-3-Clause
-  license_family: BSD
   license_file: LICENSE
   summary: Connecting awkward-array and Dask.
   description: |
     dask-awkward provides a native Dask collection representing
     partitioned awkward arrays.
-  doc_url: https://dask-awkward.readthedocs.io/
-  dev_url: https://github.com/dask-contrib/dask-awkward/
+  homepage: https://dask-awkward.readthedocs.io/
+  repository: https://github.com/dask-contrib/dask-awkward/
+  documentation: https://dask-awkward.readthedocs.io/
 
 extra:
   recipe-maintainers:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -36,7 +36,7 @@ tests:
   - python:
       imports:
         - dask_awkward
-      pip_check: false
+      pip_check: true
 
       python_version: ${{ python_min }}.*
 about:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -20,7 +20,7 @@ build:
 
 requirements:
   host:
-    - python 3.8.*
+    - python ${{ python_min }}.*
     - pip
     - hatchling >=1.8.0
     - hatch-vcs


### PR DESCRIPTION
This PR converts dask-awkward-feedstock to a v1 recipe and switch the conda build tool to rattler-build.
It has been automatically generated with [feedrattler v0.3.12](https://github.com/hadim/feedrattler).

Changes:
- [x] 📝 Converted `meta.yaml` to `recipe.yaml`
- [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
- [x] 🔧 Updated `conda-forge.yml` to use `rattler-build` and `pixi` (optional)
- [x] 🔢 Bumped the build number
- [x] 🐍 Applied temporary fixes for `python_min` and `python_version`
- [x] 🔄 Rerender the feedstock with conda-smithy
- [ ] Ensured the license file is being packaged.
